### PR TITLE
Bugfix - Base files not uploading

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "moss_rs"
 authors = ["Ian Akotey"]
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 
 [lib]

--- a/src/client/client.rs
+++ b/src/client/client.rs
@@ -87,7 +87,8 @@ impl<S: ToSocketAddrs> MossClient<S> {
                                 .skip(1)
                                 .flatten()
                                 .map(|c| c.as_str())
-                                .intersperse("/").collect::<String>()
+                                .intersperse("/")
+                                .collect::<String>(),
                         )
                     } else {
                         file_path
@@ -181,6 +182,7 @@ impl<S: ToSocketAddrs> MossClient<S> {
     }
 
     fn _upload_base_files(&self) -> Result<(), Whatever> {
+        // dbg!(format!("Uploading the following base files: {:?}", self.config.base_files().collect::<Vec<_>>()));
         for file in self.config.base_files() {
             self._send_file(file, 0)?;
         }


### PR DESCRIPTION
## Problem

base files specified using the -b flag were not uploaded to MOSS

## Explanation

Clap V^3.2.17 does not seem to remove spaces when parsing the file passed using -b. i.e. "-b foo.txt" results in a PathBuf  " foo.txt", rather than "foo.txt", as expected.

## Solution

Trim the &str obtained from a possibly lossy conversion. Issue may be fixed in clap V4, so this issue will be reconsidered during a dependency version bump.